### PR TITLE
fix src for img 1

### DIFF
--- a/assets/workflow/Immunobiology/CITEseq-protocol.html
+++ b/assets/workflow/Immunobiology/CITEseq-protocol.html
@@ -822,9 +822,8 @@
           <img
             width="503"
             height="429"
-            src="/assets/workflow/Immunobiology/
-        cite-image-1.jpg"
-            alt="computer Description automatically generated 
+            src="/assets/workflow/Immunobiology/cite-image-1.jpg"
+            alt="computer Description automatically generated
 with low confidence"
             style="vertical-align: middle"
           /><br />


### PR DESCRIPTION
the indentation before cite-image-1.jpg are taken as %20 which is url escape code for space) which make the src for this img ```http://hpap-dev.pmacs.upenn.edu:5810/assets/workflow/Immunobiology/%20%20%20%20%20%20%20%20cite-image-1.jpg``` which is an invalid url